### PR TITLE
Add partial mocking

### DIFF
--- a/src/Http/Faking/MockClient.php
+++ b/src/Http/Faking/MockClient.php
@@ -60,6 +60,13 @@ class MockClient
     protected static ?MockClient $globalMockClient = null;
 
     /**
+     * Whether to allow sending an actual request if no mock response is found.
+     *
+     * @var bool
+     */
+    protected bool $allowFallback = false;
+
+    /**
      * Constructor
      *
      * @param array<\Saloon\Http\Faking\MockResponse|\Saloon\Http\Faking\Fixture|callable> $mockData
@@ -67,6 +74,16 @@ class MockClient
     public function __construct(array $mockData = [])
     {
         $this->addResponses($mockData);
+    }
+
+    /**
+     * Allow sending an actual request if no mock response is found.
+     */
+    public function allowFallback(bool $allowFallback = true): static
+    {
+        $this->allowFallback = $allowFallback;
+
+        return $this;
     }
 
     /**
@@ -137,7 +154,7 @@ class MockClient
      *
      * @throws \Saloon\Exceptions\NoMockResponseFoundException
      */
-    public function guessNextResponse(PendingRequest $pendingRequest): MockResponse|Fixture
+    public function guessNextResponse(PendingRequest $pendingRequest): MockResponse|Fixture|PendingRequest
     {
         $request = $pendingRequest->getRequest();
         $requestClass = get_class($request);
@@ -158,11 +175,17 @@ class MockClient
             return $this->mockResponseValue($guessedResponse, $pendingRequest);
         }
 
-        if (empty($this->sequenceResponses)) {
-            throw new NoMockResponseFoundException($pendingRequest);
+        $sequenceResponse = $this->getNextFromSequence();
+
+        if (! empty($sequenceResponse)) {
+            return $this->mockResponseValue($sequenceResponse, $pendingRequest);
         }
 
-        return $this->mockResponseValue($this->getNextFromSequence(), $pendingRequest);
+        if ($this->allowFallback) {
+            return $pendingRequest;
+        }
+
+        throw new NoMockResponseFoundException($pendingRequest);
     }
 
     /**

--- a/tests/Unit/MockClientTest.php
+++ b/tests/Unit/MockClientTest.php
@@ -111,7 +111,7 @@ test('you can create wildcard url mocks', function () {
     expect($mockClient->guessNextResponse($connectorB->createPendingRequest($requestC)))->toEqual($responseC);
 });
 
-test('saloon throws an exception if it cant work out the url response', function () {
+test('saloon throws an exception if it cant work out the url response', function (bool $allowFallback) {
     $responseA = MockResponse::make(['name' => 'Sammyjo20']);
     $responseB = MockResponse::make(['name' => 'Alex']);
     $responseC = MockResponse::make(['name' => 'Sam Carré']);
@@ -128,14 +128,25 @@ test('saloon throws an exception if it cant work out the url response', function
         'tests.saloon.dev/*' => $responseB, // Test Wildcard Routes
     ]);
 
+    $mockClient->allowFallback($allowFallback);
+
     expect($mockClient->guessNextResponse($connectorA->createPendingRequest($requestA)))->toEqual($responseA);
     expect($mockClient->guessNextResponse($connectorA->createPendingRequest($requestB)))->toEqual($responseB);
 
-    $this->expectException(NoMockResponseFoundException::class);
-    $this->expectExceptionMessage('Saloon was unable to guess a mock response for your request [https://google.com/user], consider using a wildcard url mock or a connector mock.');
+    if ($allowFallback) {
+        $pendingRequest = $connectorB->createPendingRequest($requestC);
 
-    expect($mockClient->guessNextResponse($connectorB->createPendingRequest($requestC)))->toEqual($responseC);
-});
+        expect($mockClient->guessNextResponse($pendingRequest))->toEqual($pendingRequest);
+    } else {
+        $this->expectException(NoMockResponseFoundException::class);
+        $this->expectExceptionMessage('Saloon was unable to guess a mock response for your request [https://google.com/user], consider using a wildcard url mock or a connector mock.');
+
+        expect($mockClient->guessNextResponse($connectorB->createPendingRequest($requestC)))->toEqual($responseC);
+    }
+})->with([
+    true,
+    false,
+]);
 
 test('you can get an array of the recorded requests', function () {
     $mockClient = new MockClient([


### PR DESCRIPTION
Adds an `allowFallback()` method to the `MockClient`. This returns the `$pendingRequest` instead of throwing `NoMockResponseFoundException`, allowing the request pipeline to continue (and send an actual request).

Closes #501.