### PR TITLE
Add PHPStan generics to Request, Response and send() for typed DTO inference

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,7 +1,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Call to an undefined method GuzzleHttp\\Promise\\PromiseInterface\|Saloon\\Http\\Response\:\:then\(\)\.$#'
+			message: '#^Call to an undefined method GuzzleHttp\\Promise\\PromiseInterface\|Saloon\\Http\\Response\<mixed\>\:\:then\(\)\.$#'
 			identifier: method.notFound
 			count: 1
 			path: src/Http/Connector.php
@@ -25,7 +25,7 @@ parameters:
 			path: src/Http/Connector.php
 
 		-
-			message: '#^Parameter \#1 \$response of method Saloon\\Http\\PendingRequest\:\:executeResponsePipeline\(\) expects Saloon\\Http\\Response, GuzzleHttp\\Promise\\PromiseInterface\|Saloon\\Http\\Response given\.$#'
+			message: '#^Parameter \#1 \$response of method Saloon\\Http\\PendingRequest\:\:executeResponsePipeline\(\) expects Saloon\\Http\\Response\<mixed\>, GuzzleHttp\\Promise\\PromiseInterface\|Saloon\\Http\\Response\<mixed\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Http/Connector.php
@@ -37,19 +37,19 @@ parameters:
 			path: src/Http/Faking/Fixture.php
 
 		-
-			message: '#^Method Saloon\\Http\\Faking\\MockClient\:\:getLastResponse\(\) should return Saloon\\Http\\Response\|null but returns \(callable\)\|Saloon\\Http\\Faking\\Fixture\|Saloon\\Http\\Faking\\MockResponse\.$#'
+			message: '#^Method Saloon\\Http\\Faking\\MockClient\:\:getLastResponse\(\) should return Saloon\\Http\\Response\<mixed\>\|null but returns \(callable\(\)\: mixed\)\|Saloon\\Http\\Faking\\Fixture\|Saloon\\Http\\Faking\\MockResponse\.$#'
 			identifier: return.type
 			count: 1
 			path: src/Http/Faking/MockClient.php
 
 		-
-			message: '#^Method Saloon\\Http\\Faking\\MockClient\:\:getRecordedResponses\(\) should return array\<Saloon\\Http\\Response\> but returns array\<\(callable\)\|Saloon\\Http\\Faking\\Fixture\|Saloon\\Http\\Faking\\MockResponse\>\.$#'
+			message: '#^Method Saloon\\Http\\Faking\\MockClient\:\:getRecordedResponses\(\) should return array\<Saloon\\Http\\Response\<mixed\>\> but returns array\<\(callable\(\)\: mixed\)\|Saloon\\Http\\Faking\\Fixture\|Saloon\\Http\\Faking\\MockResponse\>\.$#'
 			identifier: return.type
 			count: 1
 			path: src/Http/Faking/MockClient.php
 
 		-
-			message: '#^Property Saloon\\Http\\Faking\\MockClient\:\:\$recordedResponses \(array\<\(callable\(\)\: mixed\)\|Saloon\\Http\\Faking\\Fixture\|Saloon\\Http\\Faking\\MockResponse\>\) does not accept non\-empty\-array\<\(callable\(\)\: mixed\)\|Saloon\\Http\\Faking\\Fixture\|Saloon\\Http\\Faking\\MockResponse\|Saloon\\Http\\Response\>\.$#'
+			message: '#^Property Saloon\\Http\\Faking\\MockClient\:\:\$recordedResponses \(array\<\(callable\(\)\: mixed\)\|Saloon\\Http\\Faking\\Fixture\|Saloon\\Http\\Faking\\MockResponse\>\) does not accept non\-empty\-array\<\(callable\(\)\: mixed\)\|Saloon\\Http\\Faking\\Fixture\|Saloon\\Http\\Faking\\MockResponse\|Saloon\\Http\\Response\<mixed\>\>\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: src/Http/Faking/MockClient.php

--- a/src/Contracts/DataObjects/WithResponse.php
+++ b/src/Contracts/DataObjects/WithResponse.php
@@ -11,12 +11,15 @@ interface WithResponse
     /**
      * Set the response on the data object.
      *
+     * @param Response<mixed> $response
      * @return $this
      */
     public function setResponse(Response $response): static;
 
     /**
      * Get the response on the data object.
+     *
+     * @return Response<mixed>
      */
     public function getResponse(): Response;
 }

--- a/src/Contracts/ResponseMiddleware.php
+++ b/src/Contracts/ResponseMiddleware.php
@@ -11,7 +11,8 @@ interface ResponseMiddleware
     /**
      * Register a response middleware
      *
-     * @return \Saloon\Http\Response|void
+     * @param Response<mixed> $response
+     * @return Response<mixed>|void
      */
     public function __invoke(Response $response);
 }

--- a/src/Contracts/Sender.php
+++ b/src/Contracts/Sender.php
@@ -18,6 +18,8 @@ interface Sender
 
     /**
      * Send the request synchronously
+     *
+     * @return Response<mixed>
      */
     public function send(PendingRequest $pendingRequest): Response;
 

--- a/src/Data/RecordedResponse.php
+++ b/src/Data/RecordedResponse.php
@@ -58,6 +58,8 @@ class RecordedResponse implements JsonSerializable
 
     /**
      * Create an instance from a Response
+     *
+     * @param Response<mixed> $response
      */
     public static function fromResponse(Response $response): static
     {

--- a/src/Exceptions/Request/RequestException.php
+++ b/src/Exceptions/Request/RequestException.php
@@ -21,6 +21,8 @@ class RequestException extends SaloonException
 {
     /**
      * The Saloon Response
+     *
+     * @var Response<mixed>
      */
     protected Response $response;
 
@@ -31,6 +33,8 @@ class RequestException extends SaloonException
 
     /**
      * Create the RequestException
+     *
+     * @param Response<mixed> $response
      */
     public function __construct(Response $response, ?string $message = null, int $code = 0, ?Throwable $previous = null)
     {
@@ -50,6 +54,8 @@ class RequestException extends SaloonException
 
     /**
      * Get the Saloon Response Class.
+     *
+     * @return Response<mixed>
      */
     public function getResponse(): Response
     {

--- a/src/Helpers/Debugger.php
+++ b/src/Helpers/Debugger.php
@@ -46,6 +46,8 @@ class Debugger
 
     /**
      * Debug a response with Symfony Var Dumper
+     *
+     * @param Response<mixed> $response
      */
     public static function symfonyResponseDebugger(Response $response, ResponseInterface $psrResponse): void
     {

--- a/src/Helpers/Helpers.php
+++ b/src/Helpers/Helpers.php
@@ -80,6 +80,7 @@ final class Helpers
      * Boot a plugin
      *
      * @param class-string $trait
+     * @param Connector|Request<mixed> $resource
      * @throws \ReflectionException
      */
     public static function bootPlugin(PendingRequest $pendingRequest, Connector|Request $resource, string $trait): void

--- a/src/Helpers/MiddlewarePipeline.php
+++ b/src/Helpers/MiddlewarePipeline.php
@@ -75,7 +75,7 @@ class MiddlewarePipeline
     /**
      * Add a middleware after the request is sent
      *
-     * @param callable(\Saloon\Http\Response): (\Saloon\Http\Response|void) $callable
+     * @param callable(\Saloon\Http\Response<mixed>): (\Saloon\Http\Response<mixed>|void) $callable
      * @return $this
      */
     public function onResponse(callable $callable, ?string $name = null, ?PipeOrder $order = null): static
@@ -136,6 +136,9 @@ class MiddlewarePipeline
 
     /**
      * Process the response pipeline.
+     *
+     * @param Response<mixed> $response
+     * @return Response<mixed>
      */
     public function executeResponsePipeline(Response $response): Response
     {

--- a/src/Helpers/OAuth2/OAuthConfig.php
+++ b/src/Helpers/OAuth2/OAuthConfig.php
@@ -49,7 +49,7 @@ class OAuthConfig
     /**
      * Callable that modifies the OAuth requests
      *
-     * @var \Closure(\Saloon\Http\Request): (void)|null
+     * @var \Closure(\Saloon\Http\Request<mixed>): (void)|null
      */
     protected ?Closure $requestModifier = null;
 
@@ -206,7 +206,7 @@ class OAuthConfig
     /**
      * Set the request modifier callable which can be used to modify the request being sent
      *
-     * @param callable(\Saloon\Http\Request): (void) $requestModifier
+     * @param callable(\Saloon\Http\Request<mixed>): (void) $requestModifier
      * @return $this
      */
     public function setRequestModifier(callable $requestModifier): static

--- a/src/Helpers/RequestExceptionHelper.php
+++ b/src/Helpers/RequestExceptionHelper.php
@@ -25,6 +25,8 @@ class RequestExceptionHelper
 {
     /**
      * Create the request exception from a response
+     *
+     * @param Response<mixed> $response
      */
     public static function create(Response $response, ?Throwable $previous = null): RequestException
     {

--- a/src/Http/Connector.php
+++ b/src/Http/Connector.php
@@ -21,6 +21,7 @@ use Saloon\Traits\RequestProperties\HasRequestProperties;
 
 abstract class Connector
 {
+    /** @use CreatesDtoFromResponse<mixed> */
     use CreatesDtoFromResponse;
     use AuthenticatesRequests;
     use HasRequestProperties;

--- a/src/Http/Faking/MockClient.php
+++ b/src/Http/Faking/MockClient.php
@@ -186,6 +186,8 @@ class MockClient
 
     /**
      * Record a response.
+     *
+     * @param Response<mixed> $response
      */
     public function recordResponse(Response $response): void
     {
@@ -195,7 +197,7 @@ class MockClient
     /**
      * Get all the recorded responses
      *
-     * @return array<\Saloon\Http\Response>
+     * @return array<\Saloon\Http\Response<mixed>>
      */
     public function getRecordedResponses(): array
     {
@@ -204,6 +206,8 @@ class MockClient
 
     /**
      * Get the last request that the mock manager sent.
+     *
+     * @return Request<mixed>|null
      */
     public function getLastRequest(): ?Request
     {
@@ -220,6 +224,8 @@ class MockClient
 
     /**
      * Get the last response that the mock manager sent.
+     *
+     * @return Response<mixed>|null
      */
     public function getLastResponse(): ?Response
     {
@@ -337,6 +343,8 @@ class MockClient
 
     /**
      * Assert a given request was sent.
+     *
+     * @return Response<mixed>|null
      */
     public function findResponseByRequest(string $request, ?int $index = null): ?Response
     {
@@ -369,6 +377,8 @@ class MockClient
 
     /**
      * Find a request that matches a given url pattern
+     *
+     * @return Response<mixed>|null
      */
     public function findResponseByRequestUrl(string $url, ?int $index = null): ?Response
     {

--- a/src/Http/Middleware/RecordFixture.php
+++ b/src/Http/Middleware/RecordFixture.php
@@ -33,6 +33,8 @@ class RecordFixture implements ResponseMiddleware
 
     /**
      * Store the response
+     *
+     * @param Response<mixed> $response
      */
     public function __invoke(Response $response): void
     {

--- a/src/Http/OAuth2/GetAccessTokenRequest.php
+++ b/src/Http/OAuth2/GetAccessTokenRequest.php
@@ -11,6 +11,9 @@ use Saloon\Traits\Body\HasFormBody;
 use Saloon\Helpers\OAuth2\OAuthConfig;
 use Saloon\Traits\Plugins\AcceptsJson;
 
+/**
+ * @extends Request<null>
+ */
 class GetAccessTokenRequest extends Request implements HasBody
 {
     use HasFormBody;

--- a/src/Http/OAuth2/GetClientCredentialsTokenBasicAuthRequest.php
+++ b/src/Http/OAuth2/GetClientCredentialsTokenBasicAuthRequest.php
@@ -13,6 +13,9 @@ use Saloon\Helpers\OAuth2\OAuthConfig;
 use Saloon\Traits\Plugins\AcceptsJson;
 use Saloon\Http\Auth\BasicAuthenticator;
 
+/**
+ * @extends Request<null>
+ */
 class GetClientCredentialsTokenBasicAuthRequest extends Request implements HasBody
 {
     use HasFormBody;

--- a/src/Http/OAuth2/GetClientCredentialsTokenRequest.php
+++ b/src/Http/OAuth2/GetClientCredentialsTokenRequest.php
@@ -11,6 +11,9 @@ use Saloon\Traits\Body\HasFormBody;
 use Saloon\Helpers\OAuth2\OAuthConfig;
 use Saloon\Traits\Plugins\AcceptsJson;
 
+/**
+ * @extends Request<null>
+ */
 class GetClientCredentialsTokenRequest extends Request implements HasBody
 {
     use HasFormBody;

--- a/src/Http/OAuth2/GetRefreshTokenRequest.php
+++ b/src/Http/OAuth2/GetRefreshTokenRequest.php
@@ -11,6 +11,9 @@ use Saloon\Traits\Body\HasFormBody;
 use Saloon\Helpers\OAuth2\OAuthConfig;
 use Saloon\Traits\Plugins\AcceptsJson;
 
+/**
+ * @extends Request<null>
+ */
 class GetRefreshTokenRequest extends Request implements HasBody
 {
     use HasFormBody;

--- a/src/Http/OAuth2/GetUserRequest.php
+++ b/src/Http/OAuth2/GetUserRequest.php
@@ -11,6 +11,9 @@ use Saloon\Traits\Body\HasFormBody;
 use Saloon\Helpers\OAuth2\OAuthConfig;
 use Saloon\Traits\Plugins\AcceptsJson;
 
+/**
+ * @extends Request<null>
+ */
 class GetUserRequest extends Request implements HasBody
 {
     use HasFormBody;

--- a/src/Http/PendingRequest.php
+++ b/src/Http/PendingRequest.php
@@ -46,6 +46,8 @@ class PendingRequest
 
     /**
      * The request used by the instance.
+     *
+     * @var Request<mixed>
      */
     protected Request $request;
 
@@ -76,6 +78,8 @@ class PendingRequest
 
     /**
      * Build up the request payload.
+     *
+     * @param Request<mixed> $request
      */
     public function __construct(Connector $connector, Request $request, ?MockClient $mockClient = null)
     {
@@ -147,6 +151,9 @@ class PendingRequest
 
     /**
      * Execute the response pipeline.
+     *
+     * @param Response<mixed> $response
+     * @return Response<mixed>
      */
     public function executeResponsePipeline(Response $response): Response
     {
@@ -163,6 +170,8 @@ class PendingRequest
 
     /**
      * Get the request.
+     *
+     * @return Request<mixed>
      */
     public function getRequest(): Request
     {
@@ -291,7 +300,7 @@ class PendingRequest
     /**
      * Get the response class
      *
-     * @return class-string<\Saloon\Http\Response>
+     * @return class-string<\Saloon\Http\Response<mixed>>
      * @throws \Saloon\Exceptions\InvalidResponseClassException
      */
     public function getResponseClass(): string

--- a/src/Http/Pool.php
+++ b/src/Http/Pool.php
@@ -15,14 +15,14 @@ class Pool
     /**
      * Requests inside the pool
      *
-     * @var iterable<\GuzzleHttp\Promise\PromiseInterface|\Saloon\Http\Request>
+     * @var iterable<\GuzzleHttp\Promise\PromiseInterface|\Saloon\Http\Request<mixed>>
      */
     protected iterable $requests;
 
     /**
      * Handle Response Callback
      *
-     * @var \Closure(\Saloon\Http\Response, array-key, \GuzzleHttp\Promise\PromiseInterface): (void)|null
+     * @var \Closure(\Saloon\Http\Response<mixed>, array-key, \GuzzleHttp\Promise\PromiseInterface): (void)|null
      */
     protected ?Closure $responseHandler = null;
 
@@ -50,9 +50,9 @@ class Pool
     /**
      * Constructor
      *
-     * @param iterable<\GuzzleHttp\Promise\PromiseInterface|\Saloon\Http\Request>|callable(\Saloon\Http\Connector): iterable<\GuzzleHttp\Promise\PromiseInterface|\Saloon\Http\Request> $requests
+     * @param iterable<\GuzzleHttp\Promise\PromiseInterface|\Saloon\Http\Request<mixed>>|callable(\Saloon\Http\Connector): iterable<\GuzzleHttp\Promise\PromiseInterface|\Saloon\Http\Request<mixed>> $requests
      * @param int|callable(int $pendingRequests): (int) $concurrency
-     * @param callable(\Saloon\Http\Response, array-key $key, \GuzzleHttp\Promise\PromiseInterface $poolAggregate): (void)|null $responseHandler
+     * @param callable(\Saloon\Http\Response<mixed>, array-key $key, \GuzzleHttp\Promise\PromiseInterface $poolAggregate): (void)|null $responseHandler
      * @param callable(mixed $reason, array-key $key, \GuzzleHttp\Promise\PromiseInterface $poolAggregate): (void)|null $exceptionHandler
      */
     public function __construct(Connector $connector, iterable|callable $requests = [], int|callable $concurrency = 5, callable|null $responseHandler = null, callable|null $exceptionHandler = null)
@@ -73,7 +73,7 @@ class Pool
     /**
      * Specify a callback to happen for each successful request
      *
-     * @param callable(\Saloon\Http\Response, array-key $key, \GuzzleHttp\Promise\PromiseInterface $poolAggregate): (void) $callable
+     * @param callable(\Saloon\Http\Response<mixed>, array-key $key, \GuzzleHttp\Promise\PromiseInterface $poolAggregate): (void) $callable
      * @return $this
      */
     public function withResponseHandler(callable $callable): static
@@ -112,7 +112,7 @@ class Pool
     /**
      * Set the requests
      *
-     * @param iterable<\GuzzleHttp\Promise\PromiseInterface|\Saloon\Http\Request>|callable(\Saloon\Http\Connector): iterable<\GuzzleHttp\Promise\PromiseInterface|\Saloon\Http\Request> $requests
+     * @param iterable<\GuzzleHttp\Promise\PromiseInterface|\Saloon\Http\Request<mixed>>|callable(\Saloon\Http\Connector): iterable<\GuzzleHttp\Promise\PromiseInterface|\Saloon\Http\Request<mixed>> $requests
      * @return $this
      */
     public function setRequests(iterable|callable $requests): static
@@ -133,7 +133,7 @@ class Pool
     /**
      * Get the request generator
      *
-     * @return iterable<\GuzzleHttp\Promise\PromiseInterface|\Saloon\Http\Request>
+     * @return iterable<\GuzzleHttp\Promise\PromiseInterface|\Saloon\Http\Request<mixed>>
      */
     public function getRequests(): iterable
     {

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -20,8 +20,12 @@ use Saloon\Traits\Responses\HasCustomResponses;
 use Saloon\Traits\Request\CreatesDtoFromResponse;
 use Saloon\Traits\RequestProperties\HasRequestProperties;
 
+/**
+ * @template TDto
+ */
 abstract class Request
 {
+    /** @use CreatesDtoFromResponse<TDto> */
     use CreatesDtoFromResponse;
     use AuthenticatesRequests;
     use HasRequestProperties;

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -26,6 +26,9 @@ use Saloon\Helpers\RequestExceptionHelper;
 use Saloon\Contracts\DataObjects\WithResponse;
 use Saloon\Contracts\ArrayStore as ArrayStoreContract;
 
+/**
+ * @template TDto
+ */
 class Response
 {
     use Macroable;
@@ -119,6 +122,8 @@ class Response
 
     /**
      * Get the original request that created the response.
+     *
+     * @return Request<mixed>
      */
     public function getRequest(): Request
     {
@@ -304,6 +309,8 @@ class Response
 
     /**
      * Cast the response to a DTO.
+     *
+     * @return TDto
      */
     public function dto(): mixed
     {
@@ -321,6 +328,8 @@ class Response
 
     /**
      * Convert the response into a DTO or throw a LogicException if the response failed
+     *
+     * @return TDto
      */
     public function dtoOrFail(): mixed
     {

--- a/src/Http/Senders/GuzzleSender.php
+++ b/src/Http/Senders/GuzzleSender.php
@@ -99,6 +99,7 @@ class GuzzleSender implements Sender
      *
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \Saloon\Exceptions\Request\FatalRequestException
+     * @return Response<mixed>
      */
     public function send(PendingRequest $pendingRequest): Response
     {
@@ -187,10 +188,12 @@ class GuzzleSender implements Sender
 
     /**
      * Create a response.
+     *
+     * @return Response<mixed>
      */
     protected function createResponse(ResponseInterface $psrResponse, PendingRequest $pendingRequest, RequestInterface $psrRequest, ?Exception $exception = null): Response
     {
-        /** @var class-string<\Saloon\Http\Response> $responseClass */
+        /** @var class-string<\Saloon\Http\Response<mixed>> $responseClass */
         $responseClass = $pendingRequest->getResponseClass();
 
         return $responseClass::fromPsrResponse($psrResponse, $pendingRequest, $psrRequest, $exception);

--- a/src/Http/SoloRequest.php
+++ b/src/Http/SoloRequest.php
@@ -7,6 +7,10 @@ namespace Saloon\Http;
 use Saloon\Traits\Request\HasConnector;
 use Saloon\Http\Connectors\NullConnector;
 
+/**
+ * @template TDto
+ * @extends Request<TDto>
+ */
 abstract class SoloRequest extends Request
 {
     use HasConnector;

--- a/src/Traits/Connector/ManagesFakeResponses.php
+++ b/src/Traits/Connector/ManagesFakeResponses.php
@@ -21,6 +21,7 @@ trait ManagesFakeResponses
      *
      * @throws \Saloon\Exceptions\PendingRequestException
      * @throws \Throwable
+     * @return Response<mixed>|PromiseInterface
      */
     protected function createFakeResponse(PendingRequest $pendingRequest): Response|PromiseInterface
     {
@@ -50,7 +51,7 @@ trait ManagesFakeResponses
             streamFactory: $factories->streamFactory,
         );
 
-        /** @var class-string<\Saloon\Http\Response> $responseClass */
+        /** @var class-string<\Saloon\Http\Response<mixed>> $responseClass */
         $responseClass = $pendingRequest->getResponseClass();
 
         $response = $responseClass::fromPsrResponse(

--- a/src/Traits/Connector/SendsRequests.php
+++ b/src/Traits/Connector/SendsRequests.php
@@ -24,7 +24,10 @@ trait SendsRequests
     /**
      * Send a request synchronously
      *
-     * @param callable(\Throwable, \Saloon\Http\Request): (bool)|null $handleRetry
+     * @template TDto
+     * @param Request<TDto> $request
+     * @param callable(\Throwable, \Saloon\Http\Request<mixed>): (bool)|null $handleRetry
+     * @return Response<TDto>
      */
     public function send(Request $request, ?MockClient $mockClient = null, ?callable $handleRetry = null): Response
     {
@@ -125,6 +128,8 @@ trait SendsRequests
 
     /**
      * Send a request asynchronously
+     *
+     * @param Request<mixed> $request
      */
     public function sendAsync(Request $request, ?MockClient $mockClient = null): PromiseInterface
     {
@@ -161,7 +166,9 @@ trait SendsRequests
      *
      * @deprecated This method will be removed in Saloon v4. Please refer to the documentation to see connector or request-based retry functionality.
      *
-     * @param callable(\Throwable, \Saloon\Http\Request): (bool)|null $handleRetry
+     * @param Request<mixed> $request
+     * @param callable(\Throwable, \Saloon\Http\Request<mixed>): (bool)|null $handleRetry
+     * @return Response<mixed>
      */
     public function sendAndRetry(Request $request, int $tries, int $interval = 0, ?callable $handleRetry = null, bool $throw = true, ?MockClient $mockClient = null, bool $useExponentialBackoff = false): Response
     {
@@ -175,6 +182,8 @@ trait SendsRequests
 
     /**
      * Create a new PendingRequest
+     *
+     * @param Request<mixed> $request
      */
     public function createPendingRequest(Request $request, ?MockClient $mockClient = null): PendingRequest
     {
@@ -184,9 +193,9 @@ trait SendsRequests
     /**
      * Create a request pool
      *
-     * @param iterable<\GuzzleHttp\Promise\PromiseInterface|\Saloon\Http\Request>|callable(\Saloon\Http\Connector): iterable<\GuzzleHttp\Promise\PromiseInterface|\Saloon\Http\Request> $requests
+     * @param iterable<\GuzzleHttp\Promise\PromiseInterface|\Saloon\Http\Request<mixed>>|callable(\Saloon\Http\Connector): iterable<\GuzzleHttp\Promise\PromiseInterface|\Saloon\Http\Request<mixed>> $requests
      * @param int|callable(int $pendingRequests): (int) $concurrency
-     * @param callable(\Saloon\Http\Response, array-key $key, \GuzzleHttp\Promise\PromiseInterface $poolAggregate): (void)|null $responseHandler
+     * @param callable(\Saloon\Http\Response<mixed>, array-key $key, \GuzzleHttp\Promise\PromiseInterface $poolAggregate): (void)|null $responseHandler
      * @param callable(mixed $reason, array-key $key, \GuzzleHttp\Promise\PromiseInterface $poolAggregate): (void)|null $exceptionHandler
      */
     public function pool(iterable|callable $requests = [], int|callable $concurrency = 5, callable|null $responseHandler = null, callable|null $exceptionHandler = null): Pool

--- a/src/Traits/HasDebugging.php
+++ b/src/Traits/HasDebugging.php
@@ -49,7 +49,7 @@ trait HasDebugging
      *
      * Leave blank for a default debugger (requires symfony/var-dump)
      *
-     * @param callable(\Saloon\Http\Response, \Psr\Http\Message\ResponseInterface): void|null $onResponse
+     * @param callable(\Saloon\Http\Response<mixed>, \Psr\Http\Message\ResponseInterface): void|null $onResponse
      * @return $this
      */
     public function debugResponse(?callable $onResponse = null, bool $die = false): static

--- a/src/Traits/ManagesExceptions.php
+++ b/src/Traits/ManagesExceptions.php
@@ -11,6 +11,8 @@ trait ManagesExceptions
 {
     /**
      * Determine if the request has failed.
+     *
+     * @param Response<mixed> $response
      */
     public function hasRequestFailed(Response $response): ?bool
     {
@@ -19,6 +21,8 @@ trait ManagesExceptions
 
     /**
      * Get the request exception.
+     *
+     * @param Response<mixed> $response
      */
     public function getRequestException(Response $response, ?Throwable $senderException): ?Throwable
     {
@@ -28,6 +32,8 @@ trait ManagesExceptions
     /**
      * Determine if we should throw an exception if the `$response->throw()` is
      * used, or when the `AlwaysThrowOnErrors` trait is used.
+     *
+     * @param Response<mixed> $response
      */
     public function shouldThrowRequestException(Response $response): bool
     {

--- a/src/Traits/Request/CreatesDtoFromResponse.php
+++ b/src/Traits/Request/CreatesDtoFromResponse.php
@@ -6,10 +6,16 @@ namespace Saloon\Traits\Request;
 
 use Saloon\Http\Response;
 
+/**
+ * @template TDto
+ */
 trait CreatesDtoFromResponse
 {
     /**
      * Cast the response to a DTO.
+     *
+     * @param Response<mixed> $response
+     * @return TDto|null
      */
     public function createDtoFromResponse(Response $response): mixed
     {

--- a/src/Traits/Request/HasConnector.php
+++ b/src/Traits/Request/HasConnector.php
@@ -64,6 +64,8 @@ trait HasConnector
 
     /**
      * Send a request synchronously
+     *
+     * @return Response<mixed>
      */
     public function send(?MockClient $mockClient = null): Response
     {

--- a/src/Traits/RequestProperties/HasTries.php
+++ b/src/Traits/RequestProperties/HasTries.php
@@ -47,6 +47,8 @@ trait HasTries
      *
      * You can access the response from the RequestException. You can also modify the
      * request before the next attempt is made.
+     *
+     * @param Request<mixed> $request
      */
     public function handleRetry(FatalRequestException|RequestException $exception, Request $request): bool
     {

--- a/src/Traits/Responses/HasCustomResponses.php
+++ b/src/Traits/Responses/HasCustomResponses.php
@@ -11,14 +11,14 @@ trait HasCustomResponses
      *
      * When null or an empty string, the response on the sender will be used.
      *
-     * @var class-string<\Saloon\Http\Response>|null
+     * @var class-string<\Saloon\Http\Response<mixed>>|null
      */
     protected ?string $response = null;
 
     /**
      * Resolve the custom response class
      *
-     * @return class-string<\Saloon\Http\Response>|null
+     * @return class-string<\Saloon\Http\Response<mixed>>|null
      */
     public function resolveResponseClass(): ?string
     {


### PR DESCRIPTION
Adds @template TDto to Request and Response, wires the generic through send() so that PHPStan and IDEs can infer the DTO type at the call site without any changes to runtime behaviour.

Users can now annotate their request classes:

    /** @extends Request<CustomerDto> */
    class CustomerRequest extends Request
    {
        public function createDtoFromResponse(Response $r): CustomerDto { ... }
    }

And the full chain resolves automatically:

    $response = $connector->send(new CustomerRequest()); // Response<CustomerDto>
    $dto      = $response->dto();                        // CustomerDto

All internal usages of Response and Request have been annotated with <mixed> as required by PHPStan's missingType.generics rule. No behaviour changes — pure docblock additions.