### PR TITLE
Add `MockClient::withoutCache()`

### DIFF
--- a/src/Http/Faking/MockClient.php
+++ b/src/Http/Faking/MockClient.php
@@ -59,6 +59,13 @@ class MockClient
     protected static ?MockClient $globalMockClient = null;
 
     /**
+     * When true, the response cache plugin will not read or write the cache
+     * for requests using this mock client (for example, so fixture files are
+     * re-read from disk on each request during tests).
+     */
+    protected bool $withoutResponseCache = false;
+
+    /**
      * Constructor
      *
      * @param array<\Saloon\Http\Faking\MockResponse|\Saloon\Http\Faking\Fixture|callable> $mockData
@@ -402,6 +409,26 @@ class MockClient
         }
 
         return null;
+    }
+
+    /**
+     * Disable the response cache while this mock client is in use.
+     *
+     * @return $this
+     */
+    public function withoutCache(): static
+    {
+        $this->withoutResponseCache = true;
+
+        return $this;
+    }
+
+    /**
+     * Whether the response cache plugin should bypass caching.
+     */
+    public function shouldBypassResponseCache(): bool
+    {
+        return $this->withoutResponseCache;
     }
 
     /**

--- a/tests/Unit/MockClientTest.php
+++ b/tests/Unit/MockClientTest.php
@@ -261,3 +261,13 @@ test('you can mock normal exceptions', function () {
     $response = connector()->send(new UserRequest, $mockClient);
     $response->throw();
 });
+
+test('mock client can opt out of response cache integration', function () {
+    $client = new MockClient([]);
+
+    expect($client->shouldBypassResponseCache())->toBeFalse();
+
+    $client->withoutCache();
+
+    expect($client->shouldBypassResponseCache())->toBeTrue();
+});


### PR DESCRIPTION
> [!IMPORTANT]
> Merge this one first and _then_ the Cache plugin
 
Sister PR: https://github.com/saloonphp/cache-plugin/pull/18
Fixes: https://github.com/saloonphp/saloon/issues/547

When the response cache plugin runs, it can read and write cached payloads before mocked responses are resolved again. That makes fixture-based mocks appear stuck after the first request.

This PR adds an explicit opt-out on MockClient:

- `withoutCache()`: mark this mock client so downstream code can skip response caching
- `shouldBypassResponseCache()`: query that flag (used by the cache plugin)

`Saloon::fake([...])->withoutCache()` continues to work because the Laravel helper returns the global MockClient.

This PR also Includes a unit test covering the addition.

