### PR TITLE
Fix shallow Request clone sharing query/headers/config for pooled sends

### DIFF
--- a/src/Helpers/MiddlewarePipeline.php
+++ b/src/Helpers/MiddlewarePipeline.php
@@ -38,6 +38,16 @@ class MiddlewarePipeline
     }
 
     /**
+     * Deep-clone internal pipelines so cloned requests do not share pipe state.
+     */
+    public function __clone(): void
+    {
+        $this->requestPipeline = clone $this->requestPipeline;
+        $this->responsePipeline = clone $this->responsePipeline;
+        $this->fatalPipeline = clone $this->fatalPipeline;
+    }
+
+    /**
      * Add a middleware before the request is sent
      *
      * @param callable(\Saloon\Http\PendingRequest): (\Saloon\Http\PendingRequest|\Saloon\Contracts\FakeResponse|void) $callable

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -60,6 +60,36 @@ abstract class Request
     }
 
     /**
+     * Ensure cloned requests do not share mutable object state (query, headers, etc.).
+     *
+     * Without this, a shallow clone reuses the same {@see \Saloon\Repositories\ArrayStore}
+     * instances when they were initialized before cloning, which breaks concurrent pools
+     * (e.g. paginated requests mutating the same query bag).
+     */
+    public function __clone(): void
+    {
+        if (isset($this->query)) {
+            $this->query = clone $this->query;
+        }
+
+        if (isset($this->headers)) {
+            $this->headers = clone $this->headers;
+        }
+
+        if (isset($this->config)) {
+            $this->config = clone $this->config;
+        }
+
+        if (isset($this->delay)) {
+            $this->delay = clone $this->delay;
+        }
+
+        if (isset($this->middlewarePipeline)) {
+            $this->middlewarePipeline = clone $this->middlewarePipeline;
+        }
+    }
+
+    /**
      * Define the endpoint for the request.
      */
     abstract public function resolveEndpoint(): string;

--- a/tests/Unit/RequestCloneTest.php
+++ b/tests/Unit/RequestCloneTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Http\Response;
+use Saloon\Tests\Fixtures\Connectors\TestConnector;
+use Saloon\Tests\Fixtures\Requests\UserRequest;
+
+/**
+ * Regression for https://github.com/saloonphp/saloon/issues/524
+ *
+ * Shallow-cloned requests must not share ArrayStore / pipeline instances when those
+ * were initialized before cloning (e.g. async paginated pools).
+ */
+test('cloning a request after query() is initialized gives independent query bags', function () {
+    $original = new UserRequest;
+    $original->query()->add('key', 'value');
+
+    $a = clone $original;
+    $b = clone $original;
+
+    $a->query()->add('page', 1);
+    $b->query()->add('page', 2);
+
+    expect($a->query()->get('page'))->toBe(1);
+    expect($b->query()->get('page'))->toBe(2);
+    expect($original->query()->get('page'))->toBeNull();
+    expect($original->query()->get('key'))->toBe('value');
+});
+
+test('cloning a request after headers config and delay are initialized gives independent stores', function () {
+    $original = new UserRequest;
+    $original->headers()->add('X-Test', 'one');
+    $original->config()->add('timeout', 10);
+    $original->delay()->set(5);
+
+    $clone = clone $original;
+
+    $clone->headers()->add('X-Test', 'two');
+    $clone->config()->add('timeout', 20);
+    $clone->delay()->set(15);
+
+    expect($original->headers()->get('X-Test'))->toBe('one');
+    expect($clone->headers()->get('X-Test'))->toBe('two');
+    expect($original->config()->get('timeout'))->toBe(10);
+    expect($clone->config()->get('timeout'))->toBe(20);
+    expect($original->delay()->get())->toBe(5);
+    expect($clone->delay()->get())->toBe(15);
+});
+
+test('cloning a request after middleware is initialized gives independent pipelines', function () {
+    $original = new UserRequest;
+    $original->middleware()->onResponse(static fn (Response $response): Response => $response);
+
+    $clone = clone $original;
+
+    expect($original->middleware())->not->toBe($clone->middleware());
+});
+
+test('concurrent pool sends with cloned requests do not share query mutation', function () {
+    $sequence = [];
+    for ($i = 0; $i < 10; $i++) {
+        $sequence[] = MockResponse::make(['ok' => true]);
+    }
+
+    $connector = new TestConnector;
+    $connector->withMockClient(new MockClient($sequence));
+
+    $base = new UserRequest;
+    $base->query()->add('key', 'value');
+
+    $requests = [];
+    for ($i = 1; $i <= 10; $i++) {
+        $r = clone $base;
+        $r->query()->add('page', $i);
+        $requests[] = $r;
+    }
+
+    $pagesSeen = [];
+
+    $pool = $connector->pool($requests, 5);
+    $pool->withResponseHandler(function (Response $response) use (&$pagesSeen): void {
+        $pagesSeen[] = (int) $response->getRequest()->query()->get('page');
+    });
+
+    $pool->send()->wait();
+
+    expect($pagesSeen)->toHaveCount(10);
+    expect(array_unique($pagesSeen))->toHaveCount(10);
+});

--- a/tests/Unit/RequestCloneTest.php
+++ b/tests/Unit/RequestCloneTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
+use Saloon\Http\Response;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
-use Saloon\Http\Response;
-use Saloon\Tests\Fixtures\Connectors\TestConnector;
 use Saloon\Tests\Fixtures\Requests\UserRequest;
+use Saloon\Tests\Fixtures\Connectors\TestConnector;
 
 test('cloning a request after query() is initialized gives independent query bags', function () {
     $original = new UserRequest;

--- a/tests/Unit/RequestCloneTest.php
+++ b/tests/Unit/RequestCloneTest.php
@@ -8,12 +8,6 @@ use Saloon\Http\Response;
 use Saloon\Tests\Fixtures\Connectors\TestConnector;
 use Saloon\Tests\Fixtures\Requests\UserRequest;
 
-/**
- * Regression for https://github.com/saloonphp/saloon/issues/524
- *
- * Shallow-cloned requests must not share ArrayStore / pipeline instances when those
- * were initialized before cloning (e.g. async paginated pools).
- */
 test('cloning a request after query() is initialized gives independent query bags', function () {
     $original = new UserRequest;
     $original->query()->add('key', 'value');


### PR DESCRIPTION
## Summary
Fixes https://github.com/saloonphp/saloon/issues/524.

`Request` uses lazy-initialized object stores (`query`, `headers`, `config`, `delay`, `middlewarePipeline`). PHP’s default `clone` is shallow, so if those stores are initialized **before** cloning, clones share the same instances. Concurrent pools (e.g. async pagination) then mutate the same query bag and requests can send the wrong `page` (or other params).

## Changes
- Add `Request::__clone()` to deep-clone any **initialized** mutable stores.
- Add `MiddlewarePipeline::__clone()` to clone internal `Pipeline` instances so middleware state is not shared across cloned requests.

### Before
```
Runs: 10 | Pages: 10 | Concurrency: 5

Run 1: [1,6,6,6,6,7,6,8,10,10] (unique=5/10)
Run 2: [1,6,6,6,6,6,7,8,10,9] (unique=6/10)
Run 3: [1,6,6,6,6,6,7,8,9,10] (unique=6/10)
Run 4: [1,6,6,6,6,6,7,8,9,10] (unique=6/10)
Run 5: [1,6,6,6,6,7,6,8,9,10] (unique=6/10)
Run 6: [1,6,6,6,6,6,7,8,9,10] (unique=6/10)
Run 7: [1,6,6,6,6,6,7,8,9,10] (unique=6/10)
Run 8: [1,6,6,6,6,6,8,9,8,10] (unique=5/10)
Run 9: [1,6,6,6,6,7,6,8,9,10] (unique=6/10)
Run 10: [1,6,6,6,6,6,7,8,9,10] (unique=6/10)
```

### After
```
Runs: 10 | Pages: 10 | Concurrency: 5

Run 1: [1,3,4,2,5,7,6,8,9,10] (unique=10/10)
Run 2: [1,2,3,4,6,5,8,7,9,10] (unique=10/10)
Run 3: [1,2,4,3,5,6,7,8,9,10] (unique=10/10)
Run 4: [1,2,3,4,6,5,7,8,10,9] (unique=10/10)
Run 5: [1,3,5,6,7,2,8,9,10,4] (unique=10/10)
Run 6: [1,6,4,2,5,7,3,9,8,10] (unique=10/10)
Run 7: [1,2,4,5,6,7,3,8,9,10] (unique=10/10)
Run 8: [1,2,6,3,5,7,4,8,9,10] (unique=10/10)
Run 9: [1,2,3,4,5,6,7,8,9,10] (unique=10/10)
Run 10: [1,2,4,6,5,3,9,7,10,8] (unique=10/10)
```

## Testing
- Added regression tests covering:
  - Independent `query` / `headers` / `config` / `delay` after `clone`
  - Independent middleware pipelines after `clone`
  - Concurrent `pool()` with multiple clones + distinct `page` query values