### PR TITLE
[3.x] Add opt-in path validation to `saveBodyToFile` and `getRawStream`

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -684,7 +684,7 @@ class Response
             throw new InvalidArgumentException('Path traversal detected.');
         }
 
-        if (str_contains($path, '://') || str_starts_with(strtolower($path), 'phar://') || str_starts_with(strtolower($path), 'php://') || str_starts_with(strtolower($path), 'data://')) {
+        if (str_contains($path, '://') || str_starts_with(mb_strtolower($path), 'phar://') || str_starts_with(mb_strtolower($path), 'php://') || str_starts_with(mb_strtolower($path), 'data://')) {
             throw new InvalidArgumentException('Stream wrappers are not allowed.');
         }
     }

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -541,7 +541,7 @@ class Response
      *
      * @return resource
      */
-    public function getRawStream(): mixed
+    public function getRawStream(bool $validatePath = false): mixed
     {
         $temporaryResource = fopen('php://temp', 'wb+');
 
@@ -549,7 +549,7 @@ class Response
             throw new LogicException('Unable to create a temporary resource for the stream.');
         }
 
-        $this->saveBodyToFile($temporaryResource, false);
+        $this->saveBodyToFile($temporaryResource, false, $validatePath);
 
         return $temporaryResource;
     }
@@ -559,10 +559,14 @@ class Response
      *
      * @param string|resource $resourceOrPath
      */
-    public function saveBodyToFile(mixed $resourceOrPath, bool $closeResource = true): void
+    public function saveBodyToFile(mixed $resourceOrPath, bool $closeResource = true, bool $validatePath = false): void
     {
         if (! is_string($resourceOrPath) && ! is_resource($resourceOrPath)) {
             throw new InvalidArgumentException('The $resourceOrPath argument must be either a file path or a resource.');
+        }
+
+        if (is_string($resourceOrPath) && $validatePath) {
+            $this->assertSafePath($resourceOrPath);
         }
 
         $resource = is_string($resourceOrPath) ? fopen($resourceOrPath, 'wb+') : $resourceOrPath;
@@ -672,5 +676,16 @@ class Response
     public function getFakeResponse(): ?FakeResponse
     {
         return $this->fakeResponse;
+    }
+
+    private function assertSafePath(string $path): void
+    {
+        if (str_contains($path, '../') || str_contains($path, '..\\')) {
+            throw new InvalidArgumentException('Path traversal detected.');
+        }
+
+        if (str_contains($path, '://') || str_starts_with(strtolower($path), 'phar://') || str_starts_with(strtolower($path), 'php://') || str_starts_with(strtolower($path), 'data://')) {
+            throw new InvalidArgumentException('Stream wrappers are not allowed.');
+        }
     }
 }

--- a/tests/Unit/ResponseTest.php
+++ b/tests/Unit/ResponseTest.php
@@ -397,6 +397,100 @@ test('you can get save the response to a file', function (mixed $resourceOrPath)
     fn () => fopen('tests/Fixtures/Saloon/Testing/streamToFile2.json', 'wb+'),
 ]);
 
+test('saveBodyToFile is backwards compatible when validatePath is disabled', function () {
+    $mockClient = new MockClient([
+        MockResponse::make(['foo' => 'bar']),
+    ]);
+
+    $response = connector()->send(new UserRequest, $mockClient);
+    $path = sys_get_temp_dir().'/saloon_bc_'.uniqid('', true).'.json';
+
+    $response->saveBodyToFile($path);
+
+    expect(file_get_contents($path))->toEqual('{"foo":"bar"}');
+
+    unlink($path);
+});
+
+test('saveBodyToFile does not validate paths when validatePath is disabled', function () {
+    $mockClient = new MockClient([
+        MockResponse::make(['foo' => 'bar']),
+    ]);
+
+    $response = connector()->send(new UserRequest, $mockClient);
+
+    expect(fn () => $response->saveBodyToFile('../unvalidated-path.json'))
+        ->not->toThrow(\InvalidArgumentException::class);
+});
+
+test('saveBodyToFile saves to a safe path when validatePath is enabled', function () {
+    $mockClient = new MockClient([
+        MockResponse::make(['foo' => 'bar']),
+    ]);
+
+    $response = connector()->send(new UserRequest, $mockClient);
+    $path = sys_get_temp_dir().'/saloon_safe_'.uniqid('', true).'.json';
+
+    $response->saveBodyToFile($path, true, true);
+
+    expect(file_get_contents($path))->toEqual('{"foo":"bar"}');
+
+    unlink($path);
+});
+
+test('saveBodyToFile rejects path traversal when validatePath is enabled', function () {
+    $mockClient = new MockClient([
+        MockResponse::make(['foo' => 'bar']),
+    ]);
+
+    $response = connector()->send(new UserRequest, $mockClient);
+    $path = sys_get_temp_dir().'/../../../etc/passwd';
+
+    expect(fn () => $response->saveBodyToFile($path, true, true))
+        ->toThrow(InvalidArgumentException::class, 'Path traversal detected.');
+});
+
+test('saveBodyToFile rejects stream wrappers when validatePath is enabled', function (string $path, string $message) {
+    $mockClient = new MockClient([
+        MockResponse::make(['foo' => 'bar']),
+    ]);
+
+    $response = connector()->send(new UserRequest, $mockClient);
+
+    expect(fn () => $response->saveBodyToFile($path, true, true))
+        ->toThrow(InvalidArgumentException::class, $message);
+})->with([
+    ['phar://malicious.phar/payload.php', 'Stream wrappers are not allowed.'],
+    ['php://filter/read=convert.base64-encode/resource=index.php', 'Stream wrappers are not allowed.'],
+    ['data://text/plain,test', 'Stream wrappers are not allowed.'],
+]);
+
+test('getRawStream remains backwards compatible when validatePath is disabled', function () {
+    $mockClient = new MockClient([
+        MockResponse::make(['foo' => 'bar']),
+    ]);
+
+    $response = connector()->send(new UserRequest, $mockClient);
+
+    $resource = $response->getRawStream();
+
+    expect($resource)->toBeResource();
+    expect(stream_get_contents($resource))->toEqual('{"foo":"bar"}');
+});
+
+test('getRawStream works when validatePath is enabled', function () {
+    $mockClient = new MockClient([
+        MockResponse::make(['foo' => 'bar']),
+    ]);
+
+    $response = connector()->send(new UserRequest, $mockClient);
+
+    $resource = $response->getRawStream(validatePath: true);
+
+    expect($resource)->toBeResource();
+    expect(stream_get_contents($resource))->toEqual('{"foo":"bar"}');
+});
+
 test('the response is macroable', function () {
     SaloonResponse::macro('yee', fn () => 'haw');
 


### PR DESCRIPTION
Hey 👋 

Currently, `saveBodyToFile` and `getRawStream` do not sanitize input paths. This allows path traversal (`../`) and malicious stream wrappers (`phar://`, `php://`, etc.) to be executed. This becomes exploitable if a developer is determining the save path dynamically, such as extracting a filename from a `Content-Disposition` header. Whilst I don't think this affects the majority of Saloon users, it's definitely worth fixing. 

This PR:

- Adds a new, opt-in `$validatePath` boolean to both methods.
- It defaults to `false` to ensure strict backwards compatibility for existing integrations.
- Adds a private `assertSafePath` helper that throws an `InvalidArgumentException` if traversal sequences or stream wrappers are detected.
- Developers dynamically saving files can now simply pass `true` to the method signature to sanitize the operation.

Tested on a Laravel 13 application and works well, we'll need to update the docs too if this proposal is accepted and merged! 