### PR TITLE
[4.x] Fix: Null header deprecated notice for PSR requests

### DIFF
--- a/src/Http/Faking/FakeResponse.php
+++ b/src/Http/Faking/FakeResponse.php
@@ -124,7 +124,7 @@ class FakeResponse implements FakeResponseContract
         $response = $responseFactory->createResponse($this->status());
 
         foreach ($this->headers()->all() as $headerName => $headerValue) {
-            $response = $response->withHeader($headerName, $headerValue);
+            $response = $response->withHeader($headerName, $headerValue ?? '');
         }
 
         return $response->withBody($this->body()->toStream($streamFactory));

--- a/src/Traits/PendingRequest/ManagesPsrRequests.php
+++ b/src/Traits/PendingRequest/ManagesPsrRequests.php
@@ -48,7 +48,7 @@ trait ManagesPsrRequests
         );
 
         foreach ($this->headers()->all() as $headerName => $headerValue) {
-            $request = $request->withHeader($headerName, $headerValue);
+            $request = $request->withHeader($headerName, $headerValue ?? '');
         }
 
         if ($this->body() instanceof BodyRepository) {

--- a/tests/Feature/PsrTest.php
+++ b/tests/Feature/PsrTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 use GuzzleHttp\Psr7\Uri;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
-use Saloon\Tests\Fixtures\Requests\ModifiedPsrUserRequest;
-use Saloon\Tests\Fixtures\Requests\NullHeaderRequest;
-use Saloon\Tests\Fixtures\Connectors\ModifiedPsrRequestConnector;
 use Saloon\Tests\Fixtures\Connectors\TestConnector;
+use Saloon\Tests\Fixtures\Requests\NullHeaderRequest;
+use Saloon\Tests\Fixtures\Requests\ModifiedPsrUserRequest;
+use Saloon\Tests\Fixtures\Connectors\ModifiedPsrRequestConnector;
 
 test('the connector and request can modify the psr request when it is created', function () {
     $mockClient = new MockClient([
@@ -29,7 +29,7 @@ test('the connector and request can modify the psr request when it is created', 
     expect($response->getPsrRequest()->getHeaders())->toHaveKey('X-Howdy', ['Yeehaw']);
 });
 
-test('The psr request and readers must be converted to empty string', function () {
+test('The psr request headers must be converted to empty string', function () {
     $mockClient = new MockClient([
         MockResponse::make(headers: ['X-Null-Header' => null]),
     ]);
@@ -42,6 +42,6 @@ test('The psr request and readers must be converted to empty string', function (
     // The request will convert null to empty string
     expect($response->getPsrRequest()->getHeader('X-Null-Header')[0])->toBe('');
 
-    // The responde will convert null header to empty string
+    // The response will convert null header to empty string
     expect($response->headers()->get('X-Null-Header'))->toBe('');
 });

--- a/tests/Feature/PsrTest.php
+++ b/tests/Feature/PsrTest.php
@@ -34,7 +34,7 @@ test('The psr request and readers must be converted to empty string', function (
         MockResponse::make(headers: ['X-Null-Header' => null]),
     ]);
 
-    $connector = new TestConnector()->debug();
+    $connector = new TestConnector();
     $connector->withMockClient($mockClient);
 
     $response = $connector->send(new NullHeaderRequest());

--- a/tests/Feature/PsrTest.php
+++ b/tests/Feature/PsrTest.php
@@ -6,7 +6,9 @@ use GuzzleHttp\Psr7\Uri;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Tests\Fixtures\Requests\ModifiedPsrUserRequest;
+use Saloon\Tests\Fixtures\Requests\NullHeaderRequest;
 use Saloon\Tests\Fixtures\Connectors\ModifiedPsrRequestConnector;
+use Saloon\Tests\Fixtures\Connectors\TestConnector;
 
 test('the connector and request can modify the psr request when it is created', function () {
     $mockClient = new MockClient([
@@ -25,4 +27,21 @@ test('the connector and request can modify the psr request when it is created', 
     // The request will add the X-Howdy header
 
     expect($response->getPsrRequest()->getHeaders())->toHaveKey('X-Howdy', ['Yeehaw']);
+});
+
+test('The psr request and readers must be converted to empty string', function () {
+    $mockClient = new MockClient([
+        MockResponse::make(headers: ['X-Null-Header' => null]),
+    ]);
+
+    $connector = new TestConnector()->debug();
+    $connector->withMockClient($mockClient);
+
+    $response = $connector->send(new NullHeaderRequest());
+
+    // The request will convert null to empty string
+    expect($response->getPsrRequest()->getHeader('X-Null-Header')[0])->toBe('');
+
+    // The responde will convert null header to empty string
+    expect($response->headers()->get('X-Null-Header'))->toBe('');
 });

--- a/tests/Fixtures/Requests/NullHeaderRequest.php
+++ b/tests/Fixtures/Requests/NullHeaderRequest.php
@@ -30,11 +30,4 @@ class NullHeaderRequest extends Request
             'X-Null-Header' => null,
         ];
     }
-
-    protected function defaultConfig(): array
-    {
-        return [
-            'timeout' => 5,
-        ];
-    }
 }

--- a/tests/Fixtures/Requests/NullHeaderRequest.php
+++ b/tests/Fixtures/Requests/NullHeaderRequest.php
@@ -6,7 +6,6 @@ namespace Saloon\Tests\Fixtures\Requests;
 
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
-use Saloon\Tests\Fixtures\Connectors\HeaderConnector;
 
 class NullHeaderRequest extends Request
 {

--- a/tests/Fixtures/Requests/NullHeaderRequest.php
+++ b/tests/Fixtures/Requests/NullHeaderRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Tests\Fixtures\Requests;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Tests\Fixtures\Connectors\HeaderConnector;
+
+class NullHeaderRequest extends Request
+{
+    /**
+     * Define the method that the request will use.
+     *
+     * @var string
+     */
+    protected Method $method = Method::GET;
+
+    /**
+     * Define the endpoint for the request.
+     */
+    public function resolveEndpoint(): string
+    {
+        return '/user';
+    }
+
+    protected function defaultHeaders(): array
+    {
+        return [
+            'X-Null-Header' => null,
+        ];
+    }
+
+    protected function defaultConfig(): array
+    {
+        return [
+            'timeout' => 5,
+        ];
+    }
+}


### PR DESCRIPTION
Notice: Since guzzlehttp/psr7 2.11: Passing null to MessageInterface::withHeader() is deprecated; guzzlehttp/psr7 3.0 requires string|string[].

I sugest this instead of removing the header, because its easier to debug when you see an empty reader, than no header set