### PR TITLE
Static analysis improvements for macros

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,5 +75,12 @@
         "pstan": [
             "./vendor/bin/phpstan analyse --memory-limit=1G"
         ]
+    },
+    "extra": {
+        "phpstan": {
+            "includes": [
+                "extension.neon"
+            ]
+        }
     }
 }

--- a/extension.neon
+++ b/extension.neon
@@ -1,0 +1,5 @@
+services:
+    -
+        class: Saloon\PHPStan\MacroMethodsClassReflectionExtension
+        tags:
+            - phpstan.broker.methodsClassReflectionExtension

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -19,6 +19,9 @@ parameters:
   ignoreErrors:
   - "#^Unsafe usage of new static\\(\\)\\.$#"
 
+  excludePaths:
+  - '*/src/PHPStan/*'
+
   # Rules
 
   treatPhpDocTypesAsCertain: false

--- a/src/PHPStan/Macro.php
+++ b/src/PHPStan/Macro.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\PHPStan;
+
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\ClosureType;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\FunctionVariant;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\Generic\TemplateTypeMap;
+use PHPStan\Reflection\ClassMemberReflection;
+
+final class Macro implements MethodReflection
+{
+    /**
+     * The is static.
+     */
+    private bool $isStatic = false;
+
+    public function __construct(private ClassReflection $classReflection, private string $methodName, private ClosureType $closureType)
+    {
+    }
+
+    public function getDeclaringClass(): ClassReflection
+    {
+        return $this->classReflection;
+    }
+
+    public function isPrivate(): bool
+    {
+        return false;
+    }
+
+    public function isPublic(): bool
+    {
+        return true;
+    }
+
+    public function isFinal(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    public function isInternal(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    public function isStatic(): bool
+    {
+        return $this->isStatic;
+    }
+
+    /**
+     * Set the is static value.
+     */
+    public function setIsStatic(bool $isStatic): void
+    {
+        $this->isStatic = $isStatic;
+    }
+
+    public function getDocComment(): string|null
+    {
+        return null;
+    }
+
+    public function getName(): string
+    {
+        return $this->methodName;
+    }
+
+    public function isDeprecated(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    public function getPrototype(): ClassMemberReflection
+    {
+        return $this;
+    }
+
+    /** @inheritDoc */
+    public function getVariants(): array
+    {
+        return [
+            new FunctionVariant(TemplateTypeMap::createEmpty(), null, $this->closureType->getParameters(), $this->closureType->isVariadic(), $this->closureType->getReturnType()),
+        ];
+    }
+
+    public function getDeprecatedDescription(): string|null
+    {
+        return null;
+    }
+
+    public function getThrowType(): null
+    {
+        return null;
+    }
+
+    public function hasSideEffects(): TrinaryLogic
+    {
+        return TrinaryLogic::createMaybe();
+    }
+}

--- a/src/PHPStan/MacroMethodsClassReflectionExtension.php
+++ b/src/PHPStan/MacroMethodsClassReflectionExtension.php
@@ -24,6 +24,11 @@ use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
 use PHPStan\Reflection\MissingMethodFromReflectionException;
 
+/**
+ * Many thanks to Larastan for building this excellent extension.
+ *
+ * @see https://github.com/larastan/larastan/blob/3.x/src/Methods/MacroMethodsClassReflectionExtension.php
+ */
 class MacroMethodsClassReflectionExtension implements MethodsClassReflectionExtension
 {
     /** @var array<string, MethodReflection> */

--- a/src/PHPStan/MacroMethodsClassReflectionExtension.php
+++ b/src/PHPStan/MacroMethodsClassReflectionExtension.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\PHPStan;
+
+use Closure;
+use function explode;
+use function in_array;
+use function is_array;
+use function get_class;
+use function is_string;
+use function array_keys;
+use ReflectionException;
+use function is_callable;
+use function str_contains;
+use Saloon\Traits\Macroable;
+use function array_key_exists;
+use PHPStan\Type\ClosureTypeFactory;
+use PHPStan\ShouldNotHappenException;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Reflection\MethodsClassReflectionExtension;
+use PHPStan\Reflection\MissingMethodFromReflectionException;
+
+class MacroMethodsClassReflectionExtension implements MethodsClassReflectionExtension
+{
+    /** @var array<string, MethodReflection> */
+    private array $methods = [];
+
+    /** @var array<string, array<string, bool>> */
+    private array $traitCache = [];
+
+    public function __construct(private ReflectionProvider $reflectionProvider, private ClosureTypeFactory $closureTypeFactory)
+    {
+    }
+
+    /**
+     * @throws ReflectionException
+     * @throws ShouldNotHappenException
+     * @throws MissingMethodFromReflectionException
+     */
+    public function hasMethod(ClassReflection $classReflection, string $methodName): bool
+    {
+        /** @var class-string[] $classNames */
+        $classNames = [];
+        $found = false;
+        $macroTraitProperty = null;
+
+        if ($this->hasIndirectTraitUse($classReflection, Macroable::class)) {
+            $classNames = [$classReflection->getName()];
+            $macroTraitProperty = 'macros';
+        }
+
+        if ($classNames !== [] && $macroTraitProperty) {
+            foreach ($classNames as $className) {
+                $macroClassReflection = $this->reflectionProvider->getClass($className);
+
+                if (! $macroClassReflection->getNativeReflection()->hasProperty($macroTraitProperty)) {
+                    continue;
+                }
+
+                $refProperty = $macroClassReflection->getNativeReflection()->getProperty($macroTraitProperty);
+
+                $found = array_key_exists($methodName, $refProperty->getValue());
+
+                if (! $found) {
+                    continue;
+                }
+
+                $macroDefinition = $refProperty->getValue()[$methodName];
+
+                if (is_string($macroDefinition)) {
+                    if (str_contains($macroDefinition, '::')) {
+                        $macroDefinition = explode('::', $macroDefinition, 2);
+                        $macroClassName = $macroDefinition[0];
+                        if (! $this->reflectionProvider->hasClass($macroClassName) || ! $this->reflectionProvider->getClass($macroClassName)->hasNativeMethod($macroDefinition[1])) {
+                            throw new ShouldNotHappenException('Class ' . $macroClassName . ' does not exist');
+                        }
+
+                        $methodReflection = $this->reflectionProvider->getClass($macroClassName)->getNativeMethod($macroDefinition[1]);
+                    } elseif (is_callable($macroDefinition)) {
+                        $methodReflection = new Macro(
+                            $macroClassReflection,
+                            $methodName,
+                            $this->closureTypeFactory->fromClosureObject(Closure::fromCallable($macroDefinition)),
+                        );
+                    } else {
+                        throw new ShouldNotHappenException('Function ' . $macroDefinition . ' does not exist');
+                    }
+                } elseif (is_array($macroDefinition)) {
+                    if (is_string($macroDefinition[0])) {
+                        $macroClassName = $macroDefinition[0];
+                    } else {
+                        $macroClassName = get_class($macroDefinition[0]);
+                    }
+
+                    if ($macroClassName === false || ! $this->reflectionProvider->hasClass($macroClassName) || ! $this->reflectionProvider->getClass($macroClassName)->hasNativeMethod($macroDefinition[1])) {
+                        throw new ShouldNotHappenException('Class ' . $macroClassName . ' does not exist');
+                    }
+
+                    $methodReflection = $this->reflectionProvider->getClass($macroClassName)->getNativeMethod($macroDefinition[1]);
+                } else {
+                    $methodReflection = new Macro(
+                        $macroClassReflection,
+                        $methodName,
+                        $this->closureTypeFactory->fromClosureObject($macroDefinition),
+                    );
+
+                    $methodReflection->setIsStatic(true);
+                }
+
+                $this->methods[$classReflection->getName() . '-' . $methodName] = $methodReflection;
+
+                break;
+            }
+        }
+
+        return $found;
+    }
+
+    public function getMethod(
+        ClassReflection $classReflection,
+        string $methodName,
+    ): MethodReflection {
+        return $this->methods[$classReflection->getName() . '-' . $methodName];
+    }
+
+    private function hasIndirectTraitUse(ClassReflection $class, string $traitName): bool
+    {
+        $className = $class->getName();
+
+        if (array_key_exists($className, $this->traitCache) && array_key_exists($traitName, $this->traitCache[$className])) {
+            return $this->traitCache[$className][$traitName];
+        }
+
+        $this->traitCache[$className][$traitName] = in_array($traitName, array_keys($class->getTraits(true)), true);
+
+        return $this->traitCache[$className][$traitName];
+    }
+}

--- a/src/Traits/Macroable.php
+++ b/src/Traits/Macroable.php
@@ -25,6 +25,8 @@ trait Macroable
 
     /**
      * Create a macro
+     *
+     * @param-closure-this static $macro
      */
     public static function macro(string $name, object|callable $macro): void
     {


### PR DESCRIPTION
This PR improves the static analysis with PHPStan in projects when using macros. It is twofold:
1. Typehint `$this` inside the macro
2. Detect macros where used

For point 1, I took inspiration from Laravel's [Macroable trait](https://github.com/laravel/framework/blob/13.x/src/Illuminate/Macroable/Traits/Macroable.php#L27) and added `@param-closure-this`. This ensures that within the closure, `$this` refers to the class being macro-ed instead of the class the macro is registered (like a service provider).

For point 2, I took inspiration from Larastan and how they [detect macros](https://github.com/larastan/larastan/blob/3.x/src/Methods/MacroMethodsClassReflectionExtension.php). The class is largely a one-to-one copy with some Laravel specific code removed. For ease of use, I added an extension, so the developer can simply add an include to their phpstan.neon file. It also works with auto registering extensions if `phpstan/extension-installer` is used.

```
includes:
    - ./vendor/saloonphp/saloon/extension.neon
```

---

Carbon also supports macros, [but they do it slightly differently since they don't use a trait](https://github.com/briannesbitt/Carbon/blob/master/src/Carbon/PHPStan/MacroExtension.php)