### PR TITLE
feat: add HTTP QUERY method support (RFC 10008)

### DIFF
--- a/src/Enums/Method.php
+++ b/src/Enums/Method.php
@@ -15,4 +15,5 @@ enum Method: string
     case OPTIONS = 'OPTIONS';
     case CONNECT = 'CONNECT';
     case TRACE = 'TRACE';
+    case QUERY = 'QUERY';
 }


### PR DESCRIPTION
The HTTP `QUERY` method was recently published as [RFC 10008](https://www.rfc-editor.org/info/rfc10008/). It's a safe, idempotent method that carries its query in the request body instead of the URL, solving the limitations of GET for large or sensitive queries.

This PR adds `QUERY` to `Saloon\Enums\Method`.

```php
class SearchRequest extends Request
{
    protected Method $method = Method::QUERY;
}
