### PR TITLE
Add custom sleep handler for testability

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -53,6 +53,13 @@ final class Config
     private static bool $preventStrayRequests = false;
 
     /**
+     * Custom sleep handler used instead of usleep()
+     *
+     * @var callable|null
+     */
+    private static mixed $sleepHandler = null;
+
+    /**
      * Write a custom sender resolver
      */
     public static function setSenderResolver(?callable $senderResolver): void
@@ -106,5 +113,27 @@ final class Config
     public static function allowStrayRequests(): void
     {
         self::$preventStrayRequests = false;
+    }
+
+    /**
+     * Write a custom sleep handler
+     *
+     * The handler receives the number of microseconds to sleep for. Useful
+     * for skipping or observing sleeps in tests. Pass null to restore the
+     * default usleep() behaviour.
+     */
+    public static function sleepUsing(?callable $sleepHandler): void
+    {
+        self::$sleepHandler = $sleepHandler;
+    }
+
+    /**
+     * Sleep for the given number of microseconds
+     */
+    public static function sleep(int $microseconds): void
+    {
+        $sleepHandler = self::$sleepHandler;
+
+        is_callable($sleepHandler) ? $sleepHandler($microseconds) : usleep($microseconds);
     }
 }

--- a/src/Http/Middleware/DelayMiddleware.php
+++ b/src/Http/Middleware/DelayMiddleware.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Saloon\Http\Middleware;
 
+use Saloon\Config;
 use Saloon\Http\PendingRequest;
 use Saloon\Contracts\RequestMiddleware;
 
@@ -16,6 +17,8 @@ class DelayMiddleware implements RequestMiddleware
     {
         $delay = $pendingRequest->delay()->get() ?? 0;
 
-        usleep($delay * 1000);
+        if ($delay > 0) {
+            Config::sleep($delay * 1000);
+        }
     }
 }

--- a/src/Traits/Connector/SendsRequests.php
+++ b/src/Traits/Connector/SendsRequests.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Saloon\Traits\Connector;
 
+use Saloon\Config;
 use LogicException;
 use Saloon\Http\Pool;
 use Saloon\Http\Request;
@@ -58,7 +59,7 @@ trait SendsRequests
                     ? $retryInterval * (2 ** ($attempts - 2)) * 1000
                     : $retryInterval * 1000;
 
-                usleep($sleepTime);
+                Config::sleep($sleepTime);
             }
 
             try {

--- a/tests/Feature/DelayRequestTest.php
+++ b/tests/Feature/DelayRequestTest.php
@@ -2,9 +2,14 @@
 
 declare(strict_types=1);
 
+use Saloon\Config;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Tests\Fixtures\Requests\UserRequest;
+
+afterEach(function () {
+    Config::sleepUsing(null);
+});
 
 test('async request delay works', function () {
     $request = new UserRequest;
@@ -95,4 +100,25 @@ test('connector delay works', function () {
     $start = microtime(true);
     $connector->send($request);
     expect(round(microtime(true) - $start))->toBeGreaterThanOrEqual(1);
+});
+
+test('the delay is sent through the custom sleep handler when one is defined', function () {
+    $microseconds = [];
+
+    Config::sleepUsing(function (int $duration) use (&$microseconds) {
+        $microseconds[] = $duration;
+    });
+
+    $mockClient = new MockClient([
+        MockResponse::make(['name' => 'Sam']),
+    ]);
+
+    $request = new UserRequest;
+    $request->delay()->set(1000);
+
+    $start = microtime(true);
+    connector()->send($request, $mockClient);
+
+    expect(microtime(true) - $start)->toBeLessThan(1);
+    expect($microseconds)->toEqual([1_000_000]);
 });

--- a/tests/Feature/RetryRequestTest.php
+++ b/tests/Feature/RetryRequestTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Saloon\Config;
 use Saloon\Http\Request;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
@@ -12,6 +13,10 @@ use Saloon\Exceptions\Request\FatalRequestException;
 use Saloon\Tests\Fixtures\Requests\RetryUserRequest;
 use Saloon\Tests\Fixtures\Requests\HeaderErrorRetryRequest;
 use Saloon\Exceptions\Request\Statuses\InternalServerErrorException;
+
+afterEach(function () {
+    Config::sleepUsing(null);
+});
 
 test('a failed request can be retried', function () {
     $mockClient = new MockClient([
@@ -106,6 +111,29 @@ test('a failed request can have an interval between each attempt', function () {
     // after the first.
 
     expect(round(microtime(true) - $start))->toBeGreaterThanOrEqual(2);
+});
+
+test('the interval between attempts is sent through the custom sleep handler when one is defined', function () {
+    $microseconds = [];
+
+    Config::sleepUsing(function (int $duration) use (&$microseconds) {
+        $microseconds[] = $duration;
+    });
+
+    $mockClient = new MockClient([
+        MockResponse::make(['name' => 'Sam'], 500),
+        MockResponse::make(['name' => 'Gareth'], 500),
+        MockResponse::make(['name' => 'Teodor'], 200),
+    ]);
+
+    $connector = new TestConnector;
+    $connector->withMockClient($mockClient);
+
+    $connector->send(new RetryUserRequest(3, 200));
+
+    expect($microseconds)->toEqual([200_000, 200_000]);
+
+    $mockClient->assertSentCount(3);
 });
 
 test('an exception other than a request exception will not be retried', function () {

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -16,6 +16,7 @@ use Saloon\Tests\Fixtures\Connectors\TestConnector;
 afterEach(function () {
     Config::clearGlobalMiddleware();
     Config::$defaultSender = GuzzleSender::class;
+    Config::sleepUsing(null);
 });
 
 test('the config can specify global middleware', function () {
@@ -99,4 +100,16 @@ test('you can prevent and then allow stray api requests', function () {
     TestConnector::make()->send(new UserRequest);
 
     Config::clearGlobalMiddleware();
+});
+
+test('the config can specify a custom sleep handler', function () {
+    $microseconds = [];
+
+    Config::sleepUsing(function (int $duration) use (&$microseconds) {
+        $microseconds[] = $duration;
+    });
+
+    Config::sleep(50_000);
+
+    expect($microseconds)->toEqual([50_000]);
 });


### PR DESCRIPTION
Saloon sleeps with a raw `usleep()` in two places: the retry loop in `SendsRequests` and `DelayMiddleware`. These run even when requests are mocked with `MockClient`, so any test covering retries or delays pays real wall-clock time and there's no seam to avoid it. In one of our apps, a test file went from 9.5s to 4.4s once sleeps were skipped.

This PR adds a sleep seam on `Config`, mirroring `Config::setSenderResolver()`:

```php
// In a test bootstrap for skipping all sleeps
Config::sleepUsing(fn () => null);

// Restore the default behaviour
Config::sleepUsing(null);
```

Both call sites now route through `Config::sleep($microseconds)`, which falls back to `usleep()` when no handler is set.

As a follow-up, the Laravel plugin could bind the handler to `Illuminate\Support\Sleep` so `Sleep::fake()` works out of the box, happy to open that PR too.

I have considered some alternatives but  I went with a closure on `Config` because it mirrors `setSenderResolver()`, but happy to rework it if you prefer another shape:

- **A `Sleeper` contract** resolved like the sender, for an object-based seam instead of a closure.
- **A standalone helper** (e.g. `Saloon\Helpers\Sleep::for($microseconds)`) with a static test override, keeping `Config` untouched.
