### PR TITLE
Allow Guzzle 8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,9 +26,11 @@ jobs:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
         php: [ 8.2, 8.3, 8.4, 8.5 ]
-        stability: [ prefer-lowest, prefer-stable ]
+        guzzle:
+          - { constraint: '^7.6', stability: prefer-lowest }
+          - { constraint: '^8.0', stability: prefer-stable }
 
-    name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}
+    name: P${{ matrix.php }} - Guzzle ${{ matrix.guzzle.constraint }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code
@@ -48,6 +50,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+          composer require guzzlehttp/guzzle:${{ matrix.guzzle.constraint }} --no-update
+          composer update --${{ matrix.guzzle.stability }} --prefer-dist --no-interaction
       - name: Execute tests
         run: vendor/bin/pest -p

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,7 @@ jobs:
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Install dependencies
+        shell: bash
         run: |
           composer require guzzlehttp/guzzle:${{ matrix.guzzle.constraint }} --no-update
           composer update --${{ matrix.guzzle.stability }} --prefer-dist --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "homepage": "https://github.com/saloonphp/saloon",
     "require": {
         "php": "^8.2",
-        "guzzlehttp/guzzle": "^7.6",
+        "guzzlehttp/guzzle": "^7.6 || ^8.0",
         "guzzlehttp/promises": "^1.5 || ^2.0",
         "guzzlehttp/psr7": "^2.0",
         "psr/http-factory": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
     "require": {
         "php": "^8.2",
         "guzzlehttp/guzzle": "^7.6 || ^8.0",
-        "guzzlehttp/promises": "^1.5 || ^2.0",
-        "guzzlehttp/psr7": "^2.0",
+        "guzzlehttp/promises": "^1.5 || ^2.0 || ^3.0",
+        "guzzlehttp/psr7": "^2.0 || ^3.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.1 || ^2.0"
     },

--- a/src/Http/Senders/GuzzleSender.php
+++ b/src/Http/Senders/GuzzleSender.php
@@ -32,6 +32,8 @@ class GuzzleSender implements Sender
 
     /**
      * Guzzle's Handler Stack.
+     *
+     * @var HandlerStack<callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>>
      */
     protected HandlerStack $handlerStack;
 
@@ -84,6 +86,8 @@ class GuzzleSender implements Sender
 
     /**
      * The default handler stack used by the underlying Guzzle client
+     *
+     * @return HandlerStack<callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>>
      */
     protected function defaultHandlerStack(): HandlerStack
     {
@@ -118,7 +122,7 @@ class GuzzleSender implements Sender
             // Sometimes, Guzzle will throw a RequestException without a response. This
             // means that it was fatal, so we should still throw a fatal request exception.
 
-            $guzzleResponse = $exception->getResponse();
+            $guzzleResponse = method_exists($exception, 'getResponse') ? $exception->getResponse() : null;
 
             if (is_null($guzzleResponse)) {
                 throw new FatalRequestException($exception, $pendingRequest);
@@ -166,7 +170,7 @@ class GuzzleSender implements Sender
                     // Sometimes, Guzzle will throw a RequestException without a response. This
                     // means that it was fatal, so we should still throw a fatal request exception.
 
-                    $guzzleResponse = $guzzleException->getResponse();
+                    $guzzleResponse = method_exists($guzzleException, 'getResponse') ? $guzzleException->getResponse() : null;
 
                     if (is_null($guzzleResponse)) {
                         throw new FatalRequestException($guzzleException, $pendingRequest);
@@ -211,6 +215,8 @@ class GuzzleSender implements Sender
     /**
      * Overwrite the entire handler stack.
      *
+     * @param HandlerStack<callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>> $handlerStack
+     *
      * @return $this
      */
     public function setHandlerStack(HandlerStack $handlerStack): static
@@ -222,6 +228,8 @@ class GuzzleSender implements Sender
 
     /**
      * Get the handler stack.
+     *
+     * @return HandlerStack<callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>>
      */
     public function getHandlerStack(): HandlerStack
     {

--- a/tests/Feature/Body/HasMultipartBodyTest.php
+++ b/tests/Feature/Body/HasMultipartBodyTest.php
@@ -74,7 +74,6 @@ test('the guzzle sender properly sends it', function () {
             expect((string)$guzzleRequest->getBody())->toContain(
                 'X-Saloon: Yee-haw!',
                 'Content-Disposition: form-data; name="nickname"; filename="user.txt"',
-                'Content-Length: 3',
                 'Sam',
             );
 
@@ -135,7 +134,6 @@ test('can send multiple multipart files with the same key name', function () {
             expect($guzzleRequest->getBody()->getContents())->toContain(
                 'X-Saloon: Yee-haw!',
                 'Content-Disposition: form-data; name="nickname"; filename="user.txt"',
-                'Content-Length: 3',
                 'Sam',
                 'Alfie',
                 'Tom',

--- a/tests/Feature/GuzzleSenderTest.php
+++ b/tests/Feature/GuzzleSenderTest.php
@@ -80,7 +80,7 @@ test('the guzzle sender has the default handler stack configured by default', fu
     $saloonStack = invade($handlerStack)->stack;
     $defaultStack = invade(HandlerStack::create())->stack;
 
-    expect($saloonStack)->toHaveSameSize($defaultStack)->toHaveCount(4);
+    expect($saloonStack)->toHaveSameSize($defaultStack);
 
     expect($saloonStack[0][1])->toBe($defaultStack[0][1]);
     expect($saloonStack[1][1])->toBe($defaultStack[1][1]);
@@ -116,7 +116,7 @@ test('the guzzle sender has default options configured', function () {
     $saloonStack = invade($saloonConfig['handler'])->stack;
     $defaultStack = invade($defaultConfig['handler'])->stack;
 
-    expect($saloonStack)->toHaveSameSize($defaultStack)->toHaveCount(4);
+    expect($saloonStack)->toHaveSameSize($defaultStack);
 });
 
 test('you can set a custom handler stack on the guzzle sender', function () {

--- a/tests/Feature/RetryConnectorTest.php
+++ b/tests/Feature/RetryConnectorTest.php
@@ -210,7 +210,7 @@ test('you can modify the request inside the retry handler', function () {
     $connector = new RetryConnector(5, handleRetry:  function (Exception $exception, Request $request) use (&$index) {
         $index++;
 
-        $request->headers()->add('X-Test-Index', $index);
+        $request->headers()->add('X-Test-Index', (string) $index);
 
         return true;
     });
@@ -230,7 +230,7 @@ test('retry against a live endpoint to test GuzzleSender', function () {
     $requestCount = 0;
 
     $connector = new RetryConnector(6, handleRetry: function (Exception $exception, Request $request) use (&$exceptions, &$index) {
-        $request->headers()->add('X-Yee-Haw', $index++);
+        $request->headers()->add('X-Yee-Haw', (string) $index++);
 
         return true;
     });

--- a/tests/Feature/RetryRequestTest.php
+++ b/tests/Feature/RetryRequestTest.php
@@ -214,7 +214,7 @@ test('you can modify the request inside the retry handler', function () {
     $response = $connector->send(new RetryUserRequest(5, handleRetry: function (Exception $exception, Request $request) use (&$index) {
         $index++;
 
-        $request->headers()->add('X-Test-Index', $index);
+        $request->headers()->add('X-Test-Index', (string) $index);
 
         return true;
     }));
@@ -234,7 +234,7 @@ test('retry against a live endpoint to test GuzzleSender', function () {
     });
 
     $request = new HeaderErrorRetryRequest(6, handleRetry: function (Exception $exception, Request $request) use (&$exceptions, &$index) {
-        $request->headers()->add('X-Yee-Haw', $index++);
+        $request->headers()->add('X-Yee-Haw', (string) $index++);
 
         return true;
     });

--- a/tests/Feature/SendAndRetryTest.php
+++ b/tests/Feature/SendAndRetryTest.php
@@ -235,7 +235,7 @@ test('you can modify the request inside the retry handler', function () {
     $response = $connector->sendAndRetry(new UserRequest, 5, 0, function (Exception $exception, Request $request) use (&$index) {
         $index++;
 
-        $request->headers()->add('X-Test-Index', $index);
+        $request->headers()->add('X-Test-Index', (string) $index);
 
         return true;
     });
@@ -258,7 +258,7 @@ test('retry against a live endpoint to test GuzzleSender', function () {
     $index = 0;
 
     $response = $connector->sendAndRetry($request, 6, 0, function (Exception $exception, Request $request) use (&$exceptions, &$index) {
-        $request->headers()->add('X-Yee-Haw', $index++);
+        $request->headers()->add('X-Yee-Haw', (string) $index++);
 
         return true;
     });

--- a/tests/Fixtures/Senders/ArraySender.php
+++ b/tests/Fixtures/Senders/ArraySender.php
@@ -38,7 +38,7 @@ class ArraySender implements Sender
         /** @var class-string<\Saloon\Http\Response> $responseClass */
         $responseClass = $pendingRequest->getResponseClass();
 
-        return $responseClass::fromPsrResponse(new GuzzleResponse(200, ['X-Fake' => true], 'Default'), $pendingRequest, $pendingRequest->createPsrRequest());
+        return $responseClass::fromPsrResponse(new GuzzleResponse(200, ['X-Fake' => 'true'], 'Default'), $pendingRequest, $pendingRequest->createPsrRequest());
     }
 
     /**


### PR DESCRIPTION
Laravel 13 recently added support Guzzle 8 (Which is released about 1+ month ago)

This PR is to kickstart the support for Guzzle 8 (which comes with a pretty neat performance improvement)

https://github.com/laravel/framework/pull/60321

https://github.com/guzzle/guzzle/blob/8.0/UPGRADING.md